### PR TITLE
Fix SIGSEGV on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,41 @@
 > This crate is under development, feel free to contribute on [GitHub](https://github.com/EstebanBorai/network-interface). API and implementation is subject to change.
 
 The main goal of `network-interface` crate is to retrieve system's Network
-Interfaces in a standarized manner.
+Interfaces in a standardized manner.
 
-_standarized manner_ means that every supported platform must expose the same
+_standardized manner_ means that every supported platform must expose the same
 API and no further changes to the implementation are required to support such
 platform.
+
+## Usage
+```rust
+use network_interface::NetworkInterface;
+use network_interface::NetworkInterfaceConfig;
+
+fn main() {
+    let network_interfaces = NetworkInterface::show().unwrap();
+
+    for itf in network_interfaces.iter() {
+        println!("{:?}", itf);
+    }
+}
+```
+
+<details>
+  <summary>Output</summary>
+
+```
+NetworkInterface { name: "lo", addr: Some(V4(V4IfAddr { ip: 127.0.0.1, broadcast: Some(127.0.0.1), netmask: Some(255.0.0.0) })) }
+NetworkInterface { name: "wlp1s0", addr: Some(V4(V4IfAddr { ip: 192.168.0.16, broadcast: Some(192.168.0.255), netmask: Some(255.255.255.0) })) }
+NetworkInterface { name: "wg0", addr: Some(V4(V4IfAddr { ip: 10.8.0.4, broadcast: Some(10.8.0.4), netmask: Some(255.255.255.0) })) }
+NetworkInterface { name: "docker0", addr: Some(V4(V4IfAddr { ip: 172.17.0.1, broadcast: Some(172.17.255.255), netmask: Some(255.255.0.0) })) }
+NetworkInterface { name: "lo", addr: Some(V6(V6IfAddr { ip: ::1, broadcast: None, netmask: Some(ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff) })) }
+NetworkInterface { name: "wlp1s0", addr: Some(V6(V6IfAddr { ip: <redacted>, broadcast: None, netmask: Some(ffff:ffff:ffff:ffff::) })) }
+NetworkInterface { name: "docker0", addr: Some(V6(V6IfAddr { ip: <redacted>, broadcast: None, netmask: Some(ffff:ffff:ffff:ffff::) })) }
+NetworkInterface { name: "veth9d2904f", addr: Some(V6(V6IfAddr { ip: <redacted>, broadcast: None, netmask: Some(ffff:ffff:ffff:ffff::) })) }
+NetworkInterface { name: "vethcdd79af", addr: Some(V6(V6IfAddr { ip: <redacted>, broadcast: None, netmask: Some(ffff:ffff:ffff:ffff::) })) }
+```
+</details>
 
 ## Release
 

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -52,9 +52,11 @@ impl NetworkInterfaceConfig for NetworkInterface {
         while has_next(netifa) {
             let netifa_addr = unsafe { (**netifa).ifa_addr };
 
-            let netifa_family =
-                if netifa_addr.is_null() { None }
-                else { Some(unsafe { (*netifa_addr).sa_family as i32 }) };
+            let netifa_family = if netifa_addr.is_null() {
+                None
+            } else {
+                Some(unsafe { (*netifa_addr).sa_family as i32 })
+            };
 
             match netifa_family {
                 Some(AF_INET) => {


### PR DESCRIPTION
This resolves a SIGSEGV that occurs when Wireguard interfaces are present.

See also the example in `man 3 getifaddrs` which includes the same check:

```c
for (struct ifaddrs *ifa = ifaddr; ifa != NULL;
         ifa = ifa->ifa_next) {
    if (ifa->ifa_addr == NULL)
        continue;

/* ... */
```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->