### PR TITLE
fix: last node of network interfaces is missing in macOS and linux

### DIFF
--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -29,12 +29,8 @@ impl NetworkInterfaceConfig for NetworkInterface {
         let mut network_interfaces: Vec<NetworkInterface> = Vec::new();
         let netifa = addr;
 
-        let has_next = |netifa: NetIfaAddrPtr| {
+        let has_current = |netifa: NetIfaAddrPtr| {
             if unsafe { (*netifa).is_null() } {
-                return false;
-            }
-
-            if unsafe { (**netifa).ifa_next.is_null() } {
                 return false;
             }
 
@@ -49,7 +45,7 @@ impl NetworkInterfaceConfig for NetworkInterface {
             unsafe { *netifa = (**netifa).ifa_next };
         };
 
-        while has_next(netifa) {
+        while has_current(netifa) {
             let netifa_addr = unsafe { (**netifa).ifa_addr };
 
             let netifa_family = if netifa_addr.is_null() {

--- a/src/target/macos.rs
+++ b/src/target/macos.rs
@@ -27,12 +27,8 @@ impl NetworkInterfaceConfig for NetworkInterface {
         let mut network_interfaces: Vec<NetworkInterface> = Vec::new();
         let netifa = addr;
 
-        let has_next = |netifa: *mut *mut ifaddrs| {
+        let has_current = |netifa: *mut *mut ifaddrs| {
             if unsafe { (*netifa).is_null() } {
-                return false;
-            }
-
-            if unsafe { (**netifa).ifa_next.is_null() } {
                 return false;
             }
 
@@ -47,7 +43,7 @@ impl NetworkInterfaceConfig for NetworkInterface {
             unsafe { *netifa = (**netifa).ifa_next };
         };
 
-        while has_next(netifa) {
+        while has_current(netifa) {
             let netifa_addr = unsafe { (**netifa).ifa_addr };
             let netifa_family = unsafe { (*netifa_addr).sa_family as i32 };
 


### PR DESCRIPTION
Fixes bug where the last node from the linked list of network interfaces
is not taken into account in the resulting vector.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->