### PR TITLE
chore: bump `windows` crate to `0.37.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "const-sha1"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
-
-[[package]]
 name = "libc"
 version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,45 +74,43 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "windows"
-version = "0.20.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0b63f34b1cf0fcb7a2e387189936a7c9822123ef124a95da2b8a0b493bc69d"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
 dependencies = [
- "const-sha1",
- "windows_gen",
- "windows_macros",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_gen"
-version = "0.20.0"
+name = "windows_aarch64_msvc"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7213e17fead412ec608804cbe190988db6f40b2a946ef58dd67fd9cdf39da144"
-dependencies = [
- "windows_quote",
- "windows_reader",
-]
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
-name = "windows_macros"
-version = "0.20.0"
+name = "windows_i686_gnu"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661a56e1edb9f9d466a9cb59c392edfad0d273b66bb20b1f5f4aea6db5ad35d6"
-dependencies = [
- "syn",
- "windows_gen",
- "windows_quote",
- "windows_reader",
-]
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
-name = "windows_quote"
-version = "0.20.0"
+name = "windows_i686_msvc"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d16ae0ecb5b0a365ff465ca9b9780e70986f951b4e06a95f87ac54a421d3767"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
-name = "windows_reader"
-version = "0.20.0"
+name = "windows_x86_64_gnu"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75040b326c26dda15a9c18970a7a15bf503dc22597d55dd559df16435f4a550"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,5 @@ libc = "0.2.101"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libc = "0.2.101"
-windows = "0.20.0"
+windows = { version = "0.37.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper"] }
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
-windows = "0.20.0"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-fn main() {
-    #[cfg(target_family = "windows")]
-    windows::build! {
-        Windows::Win32::{
-            Networking::WinSock::{SOCKADDR_IN,SOCKADDR_IN6},
-            NetworkManagement::IpHelper::{ConvertLengthToIpv4Mask, GetAdaptersAddresses},
-        }
-    };
-}

--- a/src/target/windows.rs
+++ b/src/target/windows.rs
@@ -7,8 +7,8 @@ use std::slice::from_raw_parts;
 use libc::{free, malloc, wchar_t, wcslen};
 use windows::Win32::Networking::WinSock::{ADDRESS_FAMILY, AF_UNSPEC, SOCKADDR_IN, SOCKADDR_IN6};
 use windows::Win32::NetworkManagement::IpHelper::{
-    ConvertLengthToIpv4Mask, GetAdaptersAddresses,
-    IP_ADAPTER_ADDRESSES_LH, IP_ADAPTER_UNICAST_ADDRESS_LH,
+    ConvertLengthToIpv4Mask, GetAdaptersAddresses, IP_ADAPTER_ADDRESSES_LH,
+    IP_ADAPTER_UNICAST_ADDRESS_LH,
 };
 
 use crate::{Error, NetworkInterface, NetworkInterfaceConfig, Result};

--- a/src/target/windows.rs
+++ b/src/target/windows.rs
@@ -1,30 +1,25 @@
-mod bindings {
-    windows::include_bindings!();
-}
-
 use std::ffi::c_void;
 use std::mem::size_of;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::ptr::null_mut;
 use std::slice::from_raw_parts;
+
 use libc::{free, malloc, wchar_t, wcslen};
-
-use crate::interface::Netmask;
-use crate::{Error, NetworkInterface, NetworkInterfaceConfig, Result};
-
-use self::bindings::Windows::Win32;
-use self::Win32::Networking::WinSock::{SOCKADDR_IN, SOCKADDR_IN6};
-use self::Win32::NetworkManagement::IpHelper::{
-    ADDRESS_FAMILY, AF_UNSPEC, IP_ADAPTER_ADDRESSES_LH, IP_ADAPTER_UNICAST_ADDRESS_LH,
+use windows::Win32::Networking::WinSock::{ADDRESS_FAMILY, AF_UNSPEC, SOCKADDR_IN, SOCKADDR_IN6};
+use windows::Win32::NetworkManagement::IpHelper::{
     ConvertLengthToIpv4Mask, GetAdaptersAddresses,
+    IP_ADAPTER_ADDRESSES_LH, IP_ADAPTER_UNICAST_ADDRESS_LH,
 };
+
+use crate::{Error, NetworkInterface, NetworkInterfaceConfig, Result};
+use crate::interface::Netmask;
 
 /// An alias for `IP_ADAPTER_ADDRESSES_LH`
 type AdapterAddress = IP_ADAPTER_ADDRESSES_LH;
 
 /// An alias for `GET_ADAPTERS_ADDRESSES_FLAGS`
 type GetAdaptersAddressesFlags =
-    self::Win32::NetworkManagement::IpHelper::GET_ADAPTERS_ADDRESSES_FLAGS;
+    windows::Win32::NetworkManagement::IpHelper::GET_ADAPTERS_ADDRESSES_FLAGS;
 
 /// The buffer size indicated by the `SizePointer` parameter is too small to hold the
 /// adapter information or the `AdapterAddresses` parameter is `NULL`. The `SizePointer`
@@ -41,10 +36,10 @@ const MAX_TRIES: usize = 3;
 const GET_ADAPTERS_ADDRESSES_SUCCESS_RESULT: u32 = 0;
 
 /// A constant to store `Win32::NetworkManagement::IpHelper::AF_INET.0` casted as `u16`
-const AF_INET: u16 = self::Win32::NetworkManagement::IpHelper::AF_INET.0 as u16;
+const AF_INET: u16 = windows::Win32::Networking::WinSock::AF_INET.0 as u16;
 
 /// A constant to store `Win32::NetworkManagement::IpHelper::AF_INET6.0` casted as `u16`
-const AF_INET6: u16 = self::Win32::NetworkManagement::IpHelper::AF_INET6.0 as u16;
+const AF_INET6: u16 = windows::Win32::Networking::WinSock::AF_INET6.0 as u16;
 
 /// The address family of the addresses to retrieve. This parameter must be one of the following values.
 /// The default address family is `AF_UNSPECT` in order to gather both IPv4 and IPv6 network interfaces.
@@ -53,7 +48,7 @@ const AF_INET6: u16 = self::Win32::NetworkManagement::IpHelper::AF_INET6.0 as u1
 const GET_ADAPTERS_ADDRESSES_FAMILY: ADDRESS_FAMILY = ADDRESS_FAMILY(AF_UNSPEC.0);
 
 const GET_ADAPTERS_ADDRESSES_FLAGS: GetAdaptersAddressesFlags =
-    self::Win32::NetworkManagement::IpHelper::GAA_FLAG_INCLUDE_PREFIX;
+    windows::Win32::NetworkManagement::IpHelper::GAA_FLAG_INCLUDE_PREFIX;
 
 impl NetworkInterfaceConfig for NetworkInterface {
     fn show() -> Result<Vec<NetworkInterface>> {


### PR DESCRIPTION
The 0.20.0 version of the windows crate depends on a binding generation step that doesn't play nice with the [cross-rs](https://github.com/cross-rs/cross) `x86_64-pc-windows-gnu` target. I bumped the windows crate to the latest version which removes the generate step. Tested on gnu with cross compiling and msvc natively on windows.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->