### PR TITLE
feat: migrate from windows crate to winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ libc = "0.2.101"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libc = "0.2.101"
-windows = { version = "0.37.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper"] }
+winapi = {version = "0.3", features = ["ws2def", "ws2ipdef", "netioapi", "iphlpapi", "iptypes", "ntdef"] }
 


### PR DESCRIPTION
Unfortunately the `Windows` crate doesn't support cross compilation (see this [issue](https://github.com/microsoft/windows-rs/issues/638)).

This PR propose to migrate to the popular [winapi](https://crates.io/crates/winapi) crate which does support cross compilation and offer the same functionality.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->