### PR TITLE
feat: `serde` serialization/deserialization support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --nocapture
+          args: --all-features -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+serde = { version = "1.0.144", features = ["derive"], optional = true }
 thiserror = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -28,3 +29,5 @@ cc = "1.0.73"
 libc = "0.2.101"
 winapi = {version = "0.3", features = ["ws2def", "ws2ipdef", "netioapi", "iphlpapi", "iptypes", "ntdef"] }
 
+[features]
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde = { version = "1.0.144", features = ["derive"], optional = true }
+serde = { version = "1.0.144", optional = true }
 thiserror = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,8 @@ cc = "1.0.73"
 libc = "0.2.101"
 winapi = {version = "0.3", features = ["ws2def", "ws2ipdef", "netioapi", "iphlpapi", "iptypes", "ntdef"] }
 
+[dev-dependencies]
+serde_test = "1.0.144"
+
 [features]
 serde = ["dep:serde"]

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -4,12 +4,16 @@
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// An alias for an `Option` that wraps either a `Ipv4Addr` or a `Ipv6Addr`
 /// representing the IP for a Network Interface netmask
 pub type Netmask<T> = Option<T>;
 
 /// A system's network interface
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct NetworkInterface {
     /// Interface's name
     pub name: String,
@@ -21,6 +25,7 @@ pub struct NetworkInterface {
 
 /// Network interface address
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Addr {
     /// IPV4 Interface from the AFINET network interface family
     V4(V4IfAddr),
@@ -30,6 +35,7 @@ pub enum Addr {
 
 /// IPV4 Interface from the AFINET network interface family
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct V4IfAddr {
     /// The IP address for this network interface
     pub ip: Ipv4Addr,
@@ -41,6 +47,7 @@ pub struct V4IfAddr {
 
 /// IPV6 Interface from the AFINET6 network interface family
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct V6IfAddr {
     /// The IP address for this network interface
     pub ip: Ipv6Addr,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,10 +1,78 @@
-#[allow(unused_imports)]
-use crate::{NetworkInterface, NetworkInterfaceConfig};
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
 
-#[test]
-fn show_network_interfaces() {
-    let network_interfaces = NetworkInterface::show().unwrap();
+    #[cfg(feature = "serde")]
+    use serde_test::{Configure, Token, assert_ser_tokens};
 
-    println!("{:#?}", network_interfaces);
-    assert!(network_interfaces.len() > 1);
+    #[allow(unused_imports)]
+    use crate::{Addr, V4IfAddr, Netmask, NetworkInterface, NetworkInterfaceConfig};
+
+    #[test]
+    fn show_network_interfaces() {
+        let network_interfaces = NetworkInterface::show().unwrap();
+
+        println!("{:#?}", network_interfaces);
+        assert!(network_interfaces.len() > 1);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn network_interface_serialization() {
+        let network_interface = NetworkInterface {
+            name: String::from("Supercool"),
+            addr: Some(Addr::V4(V4IfAddr {
+                ip: Ipv4Addr::new(128, 0, 0, 1),
+                broadcast: Some(Ipv4Addr::new(127, 12, 84, 222)),
+                netmask: Some(Ipv4Addr::new(128, 1, 135, 24)),
+            })),
+            mac_addr: Some(String::from("84:62:7a:03:bd:01")),
+        };
+
+        assert_ser_tokens(
+            &network_interface.compact(),
+            &[
+                Token::Struct {
+                    name: "NetworkInterface",
+                    len: 3,
+                },
+                Token::Str("name"),
+                Token::Str("Supercool"),
+                Token::Str("addr"),
+                Token::Some,
+                Token::Struct {
+                    name: "V4IfAddr",
+                    len: 3,
+                },
+                Token::Str("ip"),
+                Token::Tuple { len: 4 },
+                Token::U8(128),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(1),
+                Token::TupleEnd,
+                Token::Str("broadcast"),
+                Token::Some,
+                Token::Tuple { len: 4 },
+                Token::U8(127),
+                Token::U8(12),
+                Token::U8(84),
+                Token::U8(222),
+                Token::TupleEnd,
+                Token::Str("netmask"),
+                Token::Some,
+                Token::Tuple { len: 4 },
+                Token::U8(128),
+                Token::U8(1),
+                Token::U8(135),
+                Token::U8(24),
+                Token::TupleEnd,
+                Token::StructEnd,
+                Token::Str("mac_addr"),
+                Token::Some,
+                Token::Str("84:62:7a:03:bd:01"),
+                Token::StructEnd,
+            ],
+        );
+    }
 }


### PR DESCRIPTION
Provides an optional feature to support `serde` for serializing
and deserializing `NetworkInterface`, `Addr`, `V4IfAddr`, `V6IfAddr`.

Resolves: https://github.com/EstebanBorai/network-interface/issues/19

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->