### PR TITLE
fix: report multiple addresses per interface on Linux and macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [main]
+### Changed
+- Changed type of `NetworkInterface::addr` to `Vec<Addr>`
+
 ## [0.1.2-beta] - 2021-10-04
 ### Fixed
 - Fixed issue where `NetworkInterface` is not being exported

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -14,7 +14,7 @@ pub struct NetworkInterface {
     /// Interface's name
     pub name: String,
     /// Interface's address
-    pub addr: Option<Addr>,
+    pub addr: Vec<Addr>,
     /// MAC Address
     pub mac_addr: Option<String>,
     /// Interface's index
@@ -68,7 +68,7 @@ impl NetworkInterface {
 
         NetworkInterface {
             name: name.to_string(),
-            addr: Some(Addr::V4(ifaddr_v4)),
+            addr: vec![Addr::V4(ifaddr_v4)],
             mac_addr: None,
             index,
         }
@@ -89,7 +89,7 @@ impl NetworkInterface {
 
         NetworkInterface {
             name: name.to_string(),
-            addr: Some(Addr::V6(ifaddr_v6)),
+            addr: vec![Addr::V6(ifaddr_v6)],
             mac_addr: None,
             index,
         }

--- a/src/target/macos/mod.rs
+++ b/src/target/macos/mod.rs
@@ -14,25 +14,29 @@ use crate::utils::{ipv4_from_in_addr, ipv6_from_in6_addr, make_ipv4_netmask, mak
 
 impl NetworkInterfaceConfig for NetworkInterface {
     fn show() -> Result<Vec<NetworkInterface>> {
-        let mut network_interfaces: HashMap<String, Vec<NetworkInterface>> = HashMap::new();
-        let mut mac_addresses: HashMap<String, String> = HashMap::new();
+        let mut network_interfaces: HashMap<String, NetworkInterface> = HashMap::new();
 
         for netifa in getifaddrs()? {
             let netifa_addr = netifa.ifa_addr;
             let netifa_family = if netifa_addr.is_null() {
-                None
+                continue;
             } else {
-                Some(unsafe { (*netifa_addr).sa_family as i32 })
+                unsafe { (*netifa_addr).sa_family as i32 }
             };
 
-            let network_interface = match netifa_family {
-                Some(AF_LINK) => {
+            let mut network_interface = match netifa_family {
+                AF_LINK => {
                     let name = make_netifa_name(&netifa)?;
                     let mac = make_mac_addrs(&netifa);
-                    mac_addresses.insert(name, mac);
-                    None
+                    let index = netifa_index(&netifa);
+                    NetworkInterface {
+                        name,
+                        mac_addr: Some(mac),
+                        addr: Vec::new(),
+                        index,
+                    }
                 }
-                Some(AF_INET) => {
+                AF_INET => {
                     let socket_addr = netifa_addr as *mut sockaddr_in;
                     let internet_address = unsafe { (*socket_addr).sin_addr };
                     let name = make_netifa_name(&netifa)?;
@@ -40,15 +44,9 @@ impl NetworkInterfaceConfig for NetworkInterface {
                     let netmask = make_ipv4_netmask(&netifa);
                     let addr = ipv4_from_in_addr(&internet_address)?;
                     let broadcast = make_ipv4_broadcast_addr(&netifa)?;
-                    Some(NetworkInterface::new_afinet(
-                        name.as_str(),
-                        addr,
-                        netmask,
-                        broadcast,
-                        index,
-                    ))
+                    NetworkInterface::new_afinet(name.as_str(), addr, netmask, broadcast, index)
                 }
-                Some(AF_INET6) => {
+                AF_INET6 => {
                     let socket_addr = netifa_addr as *mut sockaddr_in6;
                     let internet_address = unsafe { (*socket_addr).sin6_addr };
                     let name = make_netifa_name(&netifa)?;
@@ -56,37 +54,18 @@ impl NetworkInterfaceConfig for NetworkInterface {
                     let netmask = make_ipv6_netmask(&netifa);
                     let addr = ipv6_from_in6_addr(&internet_address)?;
                     let broadcast = make_ipv6_broadcast_addr(&netifa)?;
-                    Some(NetworkInterface::new_afinet6(
-                        name.as_str(),
-                        addr,
-                        netmask,
-                        broadcast,
-                        index,
-                    ))
+                    NetworkInterface::new_afinet6(name.as_str(), addr, netmask, broadcast, index)
                 }
-                _ => None,
+                _ => continue,
             };
 
-            if let Some(network_interface) = network_interface {
-                network_interfaces
-                    .entry(network_interface.name.clone())
-                    .or_default()
-                    .push(network_interface);
-            }
+            network_interfaces
+                .entry(network_interface.name.clone())
+                .and_modify(|old| old.addr.append(&mut network_interface.addr))
+                .or_insert(network_interface);
         }
 
-        for (netifa_name, mac_addr) in mac_addresses {
-            if let Some(netifas) = network_interfaces.get_mut(netifa_name.as_str()) {
-                netifas.iter_mut().for_each(|netifa| {
-                    netifa.mac_addr = Some(mac_addr.clone());
-                });
-            }
-        }
-
-        Ok(network_interfaces
-            .into_values()
-            .flat_map(|x| x.into_iter())
-            .collect())
+        Ok(network_interfaces.into_values().collect())
     }
 }
 


### PR DESCRIPTION
This PR changes `NetworkInterface::addr` to a `Vec<Addr>`, and ensures that the Linux and Mac implementation merge all entries for one interface into a single `NetworkInterface`.

This is a breaking change, of course. But it addresses #26 and #30, although the Windows platform still needs to be changed.

I don't know Windows well enough to test it, so the Windows behaviour has been unchanged (but `Some(x)` is now `vec![x]`).

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->