### PR TITLE
feat: lower MSRV to `1.54`

### DIFF
--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -130,7 +130,7 @@ fn make_mac_addrs(netifa: &libc::ifaddrs) -> String {
 
     mac_slice
         .iter()
-        .map(|x| format!("{x:02x}"))
+        .map(|x| format!("{:02x}", x))
         .collect::<Vec<_>>()
         .join(":")
 }

--- a/src/target/windows.rs
+++ b/src/target/windows.rs
@@ -244,22 +244,20 @@ fn make_ipv4_netmask(unicast_address: &*mut IP_ADAPTER_UNICAST_ADDRESS_LH) -> Ne
     let mask = unsafe { malloc(size_of::<u32>()) as *mut u32 };
     let on_link_prefix_length = unsafe { (*(*unicast_address)).OnLinkPrefixLength };
 
-    match unsafe { ConvertLengthToIpv4Mask(on_link_prefix_length as u32, mask) } {
-        0.. => {
-            let mask = unsafe { *mask };
+    unsafe { ConvertLengthToIpv4Mask(on_link_prefix_length as u32, mask) };
 
-            if cfg!(target_endian = "little") {
-                // due to a difference on how bytes are arranged on a
-                // single word of memory by the CPU, swap bytes based
-                // on CPU endianess to avoid having twisted IP addresses
-                //
-                // refer: https://github.com/rust-lang/rust/issues/48819
-                return Some(Ipv4Addr::from(mask.swap_bytes()));
-            }
+    let mask = unsafe { *mask };
 
-            Some(Ipv4Addr::from(mask))
-        }
+    if cfg!(target_endian = "little") {
+        // due to a difference on how bytes are arranged on a
+        // single word of memory by the CPU, swap bytes based
+        // on CPU endianess to avoid having twisted IP addresses
+        //
+        // refer: https://github.com/rust-lang/rust/issues/48819
+        return Some(Ipv4Addr::from(mask.swap_bytes()));
     }
+
+    Some(Ipv4Addr::from(mask))
 }
 
 fn make_ipv6_netmask(_sockaddr: &*mut SOCKADDR_IN6) -> Netmask<Ipv6Addr> {

--- a/src/utils/hex.rs
+++ b/src/utils/hex.rs
@@ -15,9 +15,9 @@ impl<'a> Display for HexSlice<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (index, byte) in self.0.iter().enumerate() {
             if index > 0 {
-                write!(f, ":{byte:02X}")?;
+                write!(f, ":{:02X}", byte)?;
             } else {
-                write!(f, "{byte:02X}")?;
+                write!(f, "{:02X}", byte)?;
             }
         }
         Ok(())


### PR DESCRIPTION
I would like to use this crate in https://github.com/ducaale/xh, but I noticed some features from Rust edition 2021 were used. This PR removes the use of named arguments in formatted strings + one redundant use of open range pattern.