### PR TITLE
fix: cross compile on macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,18 @@ fn main() {
     {
         use cc::Build;
         use std::path::Path;
+        const TARGET_MACOS: &str = "macos";
 
-        let path = Path::new("src")
-            .join("target")
-            .join("macos")
-            .join("ffi")
-            .join("lladdr.c");
+        // check cross-compile target. Only build lladdr.o when actually targeting macOS.
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+        if target_os == TARGET_MACOS {
+            let path = Path::new("src")
+                .join("target")
+                .join(TARGET_MACOS)
+                .join("ffi")
+                .join("lladdr.c");
 
-        Build::new().file(path).compile("ffi");
+            Build::new().file(path).compile("ffi");
+        }
     }
 }


### PR DESCRIPTION
For build.rs #[cfg(target_os = "macos")] is true also when cross compiling to e.g. linux.

This actual target can be detected by checking the CARGO_CFG_TARGET_OS environment variable.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->