### PR TITLE
feat: support for Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 thiserror = "1.0"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = "0.2.101"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div>
   <h1 align="center">network-interface</h1>
   <h4 align="center">
-    Retrieve system's Network Interfaces/Adapters on Linux, macOS and Windows
+    Retrieve system's Network Interfaces/Adapters on Android, Linux, macOS and Windows
     on a standarized manner
   </h4>
 </div>

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use linux::*;
 
 #[cfg(target_os = "macos")]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(windows)]
 pub mod hex;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 mod unix;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 pub use unix::*;


### PR DESCRIPTION
Android supports access to network interfaces via standard Linux socket API via the Android NDK. 
Thus we treat Android the same way as Linux.

Fixes #15.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->