### PR TITLE
feat: serde support via derive macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+serde = { version = "1.0.183", features = ["derive"] }
 thiserror = "1.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { version = "1.0.183", features = ["derive"], optional = true}
 thiserror = "1.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
@@ -29,3 +29,6 @@ cc = "1.0.73"
 libc = "0.2.101"
 winapi = {version = "0.3", features = ["ws2def", "ws2ipdef", "netioapi", "iphlpapi", "iptypes", "ntdef"] }
 
+
+[features]
+serde = ["dep:serde"]

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,6 +2,7 @@
 //! linked list provided by system functions like `getifaddrs` and
 //! `GetAdaptersAddresses`.
 use std::fmt::Debug;
+#[cfg(feature="serde")]
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -10,7 +10,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 pub type Netmask<T> = Option<T>;
 
 /// A system's network interface
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct NetworkInterface {
     /// Interface's name
     pub name: String,
@@ -23,7 +24,8 @@ pub struct NetworkInterface {
 }
 
 /// Network interface address
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Addr {
     /// IPV4 Interface from the AFINET network interface family
     V4(V4IfAddr),
@@ -32,7 +34,8 @@ pub enum Addr {
 }
 
 /// IPV4 Interface from the AFINET network interface family
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct V4IfAddr {
     /// The IP address for this network interface
     pub ip: Ipv4Addr,
@@ -43,7 +46,8 @@ pub struct V4IfAddr {
 }
 
 /// IPV6 Interface from the AFINET6 network interface family
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct V6IfAddr {
     /// The IP address for this network interface
     pub ip: Ipv6Addr,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,7 +2,7 @@
 //! linked list provided by system functions like `getifaddrs` and
 //! `GetAdaptersAddresses`.
 use std::fmt::Debug;
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,6 +2,7 @@
 //! linked list provided by system functions like `getifaddrs` and
 //! `GetAdaptersAddresses`.
 use std::fmt::Debug;
+use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// An alias for an `Option` that wraps either a `Ipv4Addr` or a `Ipv6Addr`
@@ -9,7 +10,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 pub type Netmask<T> = Option<T>;
 
 /// A system's network interface
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NetworkInterface {
     /// Interface's name
     pub name: String,
@@ -22,7 +23,7 @@ pub struct NetworkInterface {
 }
 
 /// Network interface address
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub enum Addr {
     /// IPV4 Interface from the AFINET network interface family
     V4(V4IfAddr),
@@ -31,7 +32,7 @@ pub enum Addr {
 }
 
 /// IPV4 Interface from the AFINET network interface family
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct V4IfAddr {
     /// The IP address for this network interface
     pub ip: Ipv4Addr,
@@ -42,7 +43,7 @@ pub struct V4IfAddr {
 }
 
 /// IPV6 Interface from the AFINET6 network interface family
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct V6IfAddr {
     /// The IP address for this network interface
     pub ip: Ipv6Addr,


### PR DESCRIPTION
Added serde feature to the crate with `#[derive(Serialize, Deserialize)]` on structs.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->