### PR TITLE
fix: windows broadcast address lookup

### DIFF
--- a/src/target/windows.rs
+++ b/src/target/windows.rs
@@ -204,12 +204,10 @@ fn lookup_ipv4_broadcast_addr(
                     let sockaddr: *mut SOCKADDR_IN = address.lpSockaddr as *mut SOCKADDR_IN;
                     return Some(make_ipv4_addr(&sockaddr));
                 }
-            } else {
-                if prefix_index_v4 % 3 == 1
-                    && ipv4_addr_equal(&(address.lpSockaddr as *mut SOCKADDR_IN), unicast_ip)
-                {
-                    broadcast_index = Some(prefix_index_v4 + 1);
-                }
+            } else if prefix_index_v4 % 3 == 1
+                && ipv4_addr_equal(&(address.lpSockaddr as *mut SOCKADDR_IN), unicast_ip)
+            {
+                broadcast_index = Some(prefix_index_v4 + 1);
             }
             prefix_index_v4 += 1;
         }
@@ -326,7 +324,7 @@ mod tests {
                 }
             })
             .collect();
-        assert!(mac_addr_list.len() > 0);
+        assert!(!mac_addr_list.is_empty());
 
         let interfaces = NetworkInterface::show().unwrap();
         for mac_addr in mac_addr_list {


### PR DESCRIPTION
When one network adapter has multiple ipv4 addresses, the previous implementation returned the same broadcast address for all IPs. This is fixed by correctly looking up the broadcast address in the prefix list.

Tested on 3 different Win 10 Home/Pro PCs.

Fixes #46 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->