### PR TITLE
feat(free-bsd): accept `*const i8`/`u8` for strlen arg

### DIFF
--- a/src/target/unix/mod.rs
+++ b/src/target/unix/mod.rs
@@ -72,7 +72,7 @@ impl NetworkInterfaceConfig for NetworkInterface {
 /// Retrieves the network interface name
 fn make_netifa_name(netifa: &libc::ifaddrs) -> Result<String> {
     let data = netifa.ifa_name as *mut u8;
-    let len = unsafe { strlen(data as *const i8) };
+    let len = unsafe { strlen(data as *const _) };
     let bytes_slice = unsafe { from_raw_parts(data, len) };
     let string = String::from_utf8(bytes_slice.to_vec()).map_err(Error::from)?;
 


### PR DESCRIPTION
Attempt to fix build on aarch64.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->